### PR TITLE
chore: refactor modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 secret.yaml
 /test
+.terraform

--- a/environment/locals.tf
+++ b/environment/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  vcluster_name      = nonsensitive(var.vcluster.instance.metadata.name)
+  vcluster_namespace = nonsensitive(var.vcluster.instance.metadata.namespace)
+
+  location            = nonsensitive(split(",", var.vcluster.requirements["location"])[0])
+  resource_group_name = var.vcluster.requirements["resource-group"]
+
+  vnet_cidr_block = "10.0.0.0/16"
+
+  azs = length(module.regions.regions) > 0 && length(module.regions.regions[0].zones) > 0 ? module.regions.regions[0].zones : ["1"]
+
+  public_subnets  = [for idx, az in local.azs : cidrsubnet(local.vnet_cidr_block, 8, idx)]
+  private_subnets = [for idx, az in local.azs : cidrsubnet(local.vnet_cidr_block, 8, idx + length(local.azs))]
+
+  vnet_name = format("%s-%s-vnet", local.vcluster_name, random_id.vnet_suffix.hex)
+}

--- a/environment/main.tf
+++ b/environment/main.tf
@@ -1,173 +1,81 @@
-terraform {
-  required_version = ">= 1.5"
-  required_providers {
-    azapi = {
-      source  = "azure/azapi"
-      version = "~>1.5"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~>3.0"
-    }
-  }
-}
-
-locals {
-  resource_group_name = var.vcluster.requirements["resource-group"]
-  location            = var.vcluster.requirements["location"]
-
-  vcluster_name      = nonsensitive(var.vcluster.instance.metadata.name)
-  vcluster_namespace = var.vcluster.instance.metadata.namespace
-
-  vnet_name           = "${var.vcluster.name}-${random_id.vnet_suffix.hex}-vnet"
-  vnet_cidr           = "10.0.0.0/16"
-  public_subnet_cidr  = "10.0.2.0/24"
-  public_subnet_name  = "${local.vcluster_name}-public"
-  private_subnet_cidr = "10.0.1.0/24"
-  private_subnet_name = "${local.vcluster_name}-private"
-}
-
 resource "random_id" "vnet_suffix" {
   byte_length = 4
 }
 
-provider "azurerm" {
-  features {}
-  use_cli = false
+module "regions" {
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "~> 0.7"
+
+  region_filter          = [local.location]
+  has_availability_zones = true
 }
 
-# Networking
-resource "azurerm_virtual_network" "vnet" {
+module "nat_gateway" {
+  source  = "Azure/avm-res-network-natgateway/azurerm"
+  version = "~> 0.2"
+
+  name                = format("%s-nat-gateway", local.vcluster_name)
+  location            = local.location
+  resource_group_name = local.resource_group_name
+
+  # Configure public IPs for NAT Gateway
+  public_ips = {
+    pip1 = {
+      name = format("%s-nat-pip", local.vcluster_name)
+    }
+  }
+
+  public_ip_configuration = {
+    allocation_method = "Static"
+    sku               = "Standard"
+    zones             = local.azs
+  }
+
+  tags = {
+    "Name"               = format("%s-nat-gateway", local.vcluster_name)
+    "vcluster:name"      = local.vcluster_name
+    "vcluster:namespace" = local.vcluster_namespace
+  }
+}
+
+module "vnet" {
+  source  = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version = "~> 0.10"
+
   name                = local.vnet_name
-  address_space       = [local.vnet_cidr]
   location            = local.location
   resource_group_name = local.resource_group_name
-}
+  address_space       = [local.vnet_cidr_block]
 
-resource "azurerm_subnet" "private" {
-  name                 = local.private_subnet_name
-  resource_group_name  = local.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  subnets = merge(
+    # Public subnets
+    {
+      for idx, az in local.azs : format("%s-public-%s", local.vcluster_name, az) => {
+        name             = format("%s-public-%s", local.vcluster_name, az)
+        address_prefixes = [local.public_subnets[idx]]
+      }
+    },
+    # Private subnets
+    {
+      for idx, az in local.azs : format("%s-private-%s", local.vcluster_name, az) => {
+        name             = format("%s-private-%s", local.vcluster_name, az)
+        address_prefixes = [local.private_subnets[idx]]
+        network_security_group = {
+          id = azurerm_network_security_group.workers.id
+        }
+        nat_gateway = {
+          id = module.nat_gateway.resource.id
+        }
+      }
+    }
+  )
 
-  address_prefixes = [local.private_subnet_cidr]
-}
-
-resource "azurerm_subnet" "public" {
-  name                 = local.public_subnet_name
-  resource_group_name  = local.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
-
-  address_prefixes = [local.public_subnet_cidr]
-}
-
-resource "azurerm_public_ip" "public_ip" {
-  name                = "${local.vcluster_name}-public-ip"
-  location            = local.location
-  resource_group_name = local.resource_group_name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_nat_gateway" "main" {
-  name                = "${local.vcluster_name}-nat-gateway"
-  location            = local.location
-  resource_group_name = local.resource_group_name
-  sku_name            = "Standard"
-}
-
-resource "azurerm_nat_gateway_public_ip_association" "main" {
-  nat_gateway_id       = azurerm_nat_gateway.main.id
-  public_ip_address_id = azurerm_public_ip.public_ip.id
-}
-
-resource "azurerm_subnet_nat_gateway_association" "private" {
-  nat_gateway_id = azurerm_nat_gateway.main.id
-  subnet_id      = azurerm_subnet.private.id
-}
-
-# Security Groups
-resource "azurerm_network_security_group" "public" {
-  name                = "${local.vcluster_name}-nsg-public"
-  location            = local.location
-  resource_group_name = local.resource_group_name
-
-  # Allow HTTP inbound
-  security_rule {
-    name                       = "AllowHTTP"
-    priority                   = 1001
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "80"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
+  tags = {
+    "Name"               = local.vnet_name
+    "vcluster:name"      = local.vcluster_name
+    "vcluster:namespace" = local.vcluster_namespace
   }
 
-  # Allow HTTPS inbound
-  security_rule {
-    name                       = "AllowHTTPS"
-    priority                   = 1002
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "443"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  # Allow SSH inbound
-  security_rule {
-    name                       = "AllowSSH"
-    priority                   = 1003
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-}
-resource "azurerm_network_security_group" "private" {
-  name                = "${local.vcluster_name}-nsg-private"
-  location            = local.location
-  resource_group_name = local.resource_group_name
-
-  # Allow inbound traffic from public subnet
-  security_rule {
-    name                       = "AllowFromPublicSubnet"
-    priority                   = 1001
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = local.public_subnet_cidr
-    destination_address_prefix = "*"
-  }
-
-  # Deny all other inbound traffic from internet
-  security_rule {
-    name                       = "DenyInternetInbound"
-    priority                   = 1002
-    direction                  = "Inbound"
-    access                     = "Deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "Internet"
-    destination_address_prefix = "*"
-  }
+  depends_on = [azurerm_network_security_group.workers, module.nat_gateway]
 }
 
-resource "azurerm_subnet_network_security_group_association" "public" {
-  subnet_id                 = azurerm_subnet.public.id
-  network_security_group_id = azurerm_network_security_group.public.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  subnet_id                 = azurerm_subnet.private.id
-  network_security_group_id = azurerm_network_security_group.private.id
-}

--- a/environment/nsg.tf
+++ b/environment/nsg.tf
@@ -1,0 +1,65 @@
+resource "azurerm_network_security_group" "workers" {
+  name                = format("%s-workers-nsg", local.vcluster_name)
+  location            = local.location
+  resource_group_name = local.resource_group_name
+
+  security_rule {
+    name                       = "allow-intra-vnet"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = local.vnet_cidr_block
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-kubelet"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "10250"
+    source_address_prefix      = local.vnet_cidr_block
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-nodeport-range"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "30000-32767"
+    source_address_prefix      = local.vnet_cidr_block
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-ssh-from-vnet"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = local.vnet_cidr_block
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "allow-all-outbound"
+    priority                   = 1000
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/environment/outputs.tf
+++ b/environment/outputs.tf
@@ -1,4 +1,23 @@
-output "private_subnet_id" {
-  value     = azurerm_subnet.private.id
-  sensitive = true
+output "private_subnet_ids" {
+  description = "A list of private subnet ids"
+  value = [
+    for az in local.azs : module.vnet.subnets[format("%s-private-%s", local.vcluster_name, az)].resource_id
+  ]
+}
+
+output "public_subnet_ids" {
+  description = "A list of public subnet ids"
+  value = [
+    for az in local.azs : module.vnet.subnets[format("%s-public-%s", local.vcluster_name, az)].resource_id
+  ]
+}
+
+output "security_group_id" {
+  description = "Security group id to attach to worker nodes"
+  value       = azurerm_network_security_group.workers.id
+}
+
+output "vnet_id" {
+  description = "Virtual Network ID"
+  value       = module.vnet.resource_id
 }

--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
+    }
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  use_cli = false
+}
+
+provider "azapi" {
+  use_cli = false
+}

--- a/node/locals.tf
+++ b/node/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  vcluster_name      = nonsensitive(var.vcluster.instance.metadata.name)
+  vcluster_namespace = nonsensitive(var.vcluster.instance.metadata.namespace)
+
+  location            = nonsensitive(split(",", var.vcluster.requirements["location"])[0])
+  resource_group_name = var.vcluster.requirements["resource-group"]
+
+  vm_name           = format("%s-worker-node-%s", local.vcluster_name, random_id.vm_suffix.hex)
+  private_subnet_id = var.vcluster.nodeEnvironment.outputs["private_subnet_ids"][random_integer.subnet_index.result]
+  instance_type     = var.vcluster.nodeType.spec.properties["instance-type"]
+  security_group_id = var.vcluster.nodeEnvironment.outputs["security_group_id"]
+}

--- a/node/versions.tf
+++ b/node/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
+    }
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  use_cli = false
+}
+
+provider "azapi" {
+  use_cli = false
+}

--- a/node_provider.example.yaml
+++ b/node_provider.example.yaml
@@ -13,14 +13,6 @@ spec:
         repository: https://github.com/loft-sh/vcluster-auto-nodes-azure.git
         subPath: node
     nodeTypes:
-    - name: standard-a2-v2
-      resources:
-        cpu: "2"
-        memory: 4Gi
-      properties:
-        instance-type: Standard_A2_v2
-        location: "eastus"
-        resource-group: "*"
     - name: standard-d2s-v5
       resources:
         cpu: "2"


### PR DESCRIPTION
Use Azure modules for some resources except VM ([requires tofu 1.10.0+](https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine/issues/191))
Deploy multiple AZs.
Adjust security group rules.

The Standard_A2_v2 instance type was removed as it is not a Gen2 instance and cannot be used with the Ubuntu `22_04-lts-gen2` image.