### PR TITLE
Disable Microsoft telemetry

### DIFF
--- a/environment/infrastructure/main.tf
+++ b/environment/infrastructure/main.tf
@@ -89,4 +89,6 @@ module "vnet" {
   }
 
   depends_on = [azurerm_network_security_group.workers, module.nat_gateway]
+
+  enable_telemetry = false
 }


### PR DESCRIPTION
Telemetry is enabled by default.
https://azure.github.io/Azure-Verified-Modules/help-support/telemetry/

It causes issues for destroy cmd because it uses `resource uuid` which we didn't define.
If we want to keep the telemetry enabled then i can adjust the PR with appropriate fix.